### PR TITLE
docs: expand README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,47 @@
 # SlickQueue
-A robust, ring buffer based, lock-free, header-only, C++ MPMC queue
+
+SlickQueue is a header-only C++ library that provides a lock-free,
+multi-producer multi-consumer (MPMC) queue built on a ring buffer. It is
+designed for high throughput concurrent messaging and can optionally operate
+over shared memory for inter-process communication.
+
+## Features
+
+- Lock-free operations for multiple producers and consumers
+- Header-only implementation
+- Optional shared-memory mode
+- No dynamic allocation on the hot path
+
+## Getting Started
+
+Simply add the `include` directory to your project's include path and include
+the header:
+
+```cpp
+#include "slick_queue.h"
+
+slick::SlickQueue<int> queue(1024);
+auto slot = queue.reserve();
+*queue[slot] = 42;
+queue.publish(slot);
+
+uint64_t cursor = 0;
+auto result = queue.read(cursor);
+```
+
+## Building Tests
+
+A small test suite is provided using CMake and Catch. Build and run the tests
+with:
+
+```bash
+cmake -S . -B build
+cmake --build build --target slick_queue_tests
+./build/tests/slick_queue_tests
+```
+
+## License
+
+SlickQueue is released under the [MIT License](LICENSE).
 
 


### PR DESCRIPTION
## Summary
- clarify SlickQueue overview and feature list
- add usage example and instructions for running tests

## Testing
- `cmake --build build --target slick_queue_tests` *(fails: call to non-'constexpr' function 'sysconf', wrong number of template arguments)*

------
https://chatgpt.com/codex/tasks/task_e_688fd044ad3483339f72c4ebf82aa242