### PR TITLE
Add Linux shared memory support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,4 +9,8 @@ set(CMAKE_CXX_STANDARD 17)
 add_library(slick_queue INTERFACE)
 target_include_directories(slick_queue INTERFACE include)
 
+if(UNIX AND NOT APPLE)
+    target_link_libraries(slick_queue INTERFACE rt)
+endif()
+
 add_subdirectory(tests EXCLUDE_FROM_ALL)

--- a/include/slick_queue.h
+++ b/include/slick_queue.h
@@ -20,6 +20,12 @@
 #if defined(_MSC_VER)
 #include <windows.h>
 #include <tchar.h>
+#else
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <cerrno>
 #endif
 
 namespace slick {
@@ -42,6 +48,9 @@ class SlickQueue {
 #if defined(_MSC_VER)
     HANDLE hMapFile_ = nullptr;
     LPVOID lpvMem_ = nullptr;
+#else
+    int shm_fd_ = -1;
+    void* lpvMem_ = nullptr;
 #endif
 
 public:
@@ -82,6 +91,16 @@ public:
         if (hMapFile_) {
             CloseHandle(hMapFile_);
             hMapFile_ = nullptr;
+        }
+#else
+        if (lpvMem_) {
+            auto BF_SZ = static_cast<size_t>(64 + sizeof(slot) * size_ + sizeof(T) * size_);
+            munmap(lpvMem_, BF_SZ);
+            lpvMem_ = nullptr;
+        }
+        if (shm_fd_ != -1) {
+            close(shm_fd_);
+            shm_fd_ = -1;
         }
 #endif
         
@@ -234,7 +253,70 @@ private:
         }
     }
 #else
-    void allocateShmData(const char* const shm_name) noexcept {
+    void allocate_shm_data(const char* const shm_name, bool open_only) {
+        size_t BF_SZ;
+        if (open_only) {
+            shm_fd_ = shm_open(shm_name, O_RDWR, 0666);
+            if (shm_fd_ == -1) {
+                throw std::runtime_error("Failed to open shm. err=" + std::to_string(errno));
+            }
+
+            void* tmp = mmap(nullptr, 64, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd_, 0);
+            if (tmp == MAP_FAILED) {
+                throw std::runtime_error("Failed to map shm header. err=" + std::to_string(errno));
+            }
+            mask_ = *reinterpret_cast<uint32_t*>(reinterpret_cast<uint8_t*>(tmp) + sizeof(std::atomic_uint_fast64_t)) - 1;
+            size_ = mask_ + 1025;
+            BF_SZ = 64 + sizeof(slot) * size_ + sizeof(T) * size_;
+            munmap(tmp, 64);
+
+            lpvMem_ = mmap(nullptr, BF_SZ, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd_, 0);
+            if (lpvMem_ == MAP_FAILED) {
+                throw std::runtime_error("Failed to map shm. err=" + std::to_string(errno));
+            }
+
+            reserved_ = reinterpret_cast<std::atomic_uint_fast64_t*>(lpvMem_);
+            control_ = reinterpret_cast<slot*>((uint8_t*)lpvMem_ + 64);
+            data_ = reinterpret_cast<T*>((uint8_t*)lpvMem_ + 64 + sizeof(slot) * size_);
+            own_ = false;
+        } else {
+            shm_fd_ = shm_open(shm_name, O_RDWR | O_CREAT | O_EXCL, 0666);
+            if (shm_fd_ == -1) {
+                if (errno != EEXIST) {
+                    throw std::runtime_error("Failed to create shm. err=" + std::to_string(errno));
+                }
+                shm_fd_ = shm_open(shm_name, O_RDWR, 0666);
+                if (shm_fd_ == -1) {
+                    throw std::runtime_error("Failed to open existing shm. err=" + std::to_string(errno));
+                }
+                own_ = false;
+            } else {
+                own_ = true;
+            }
+
+            BF_SZ = 64 + sizeof(slot) * size_ + sizeof(T) * size_;
+            if (own_) {
+                if (ftruncate(shm_fd_, BF_SZ) == -1) {
+                    throw std::runtime_error("Failed to size shm. err=" + std::to_string(errno));
+                }
+            }
+
+            lpvMem_ = mmap(nullptr, BF_SZ, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd_, 0);
+            if (lpvMem_ == MAP_FAILED) {
+                throw std::runtime_error("Failed to map shm. err=" + std::to_string(errno));
+            }
+
+            if (own_) {
+                reserved_ = new (lpvMem_) std::atomic_uint_fast64_t{ 0 };
+                *reinterpret_cast<uint32_t*>(reinterpret_cast<uint8_t*>(lpvMem_) + sizeof(std::atomic_uint_fast64_t)) = mask_ + 1;
+                control_ = new ((uint8_t*)lpvMem_ + 64) slot[size_];
+                data_ = new ((uint8_t*)lpvMem_ + 64 + sizeof(slot) * size_) T[size_];
+            } else {
+                reserved_ = reinterpret_cast<std::atomic_uint_fast64_t*>(lpvMem_);
+                control_ = reinterpret_cast<slot*>((uint8_t*)lpvMem_ + 64);
+                data_ = reinterpret_cast<T*>((uint8_t*)lpvMem_ + 64 + sizeof(slot) * size_);
+            }
+        }
     }
 #endif
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,3 +3,5 @@ project(slick_queue_tests LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 
 add_executable(slick_queue_tests tests.cpp shm_tests.cpp)
+
+target_link_libraries(slick_queue_tests PRIVATE slick_queue)

--- a/tests/shm_tests.cpp
+++ b/tests/shm_tests.cpp
@@ -5,14 +5,14 @@
 using namespace slick;
 
 TEST_CASE("Read empty queue - shm") {
-  SlickQueue<int> queue(2);
+  SlickQueue<int> queue(2, "sq_read_empty");
   uint64_t read_cursor = 0;
   auto read = queue.read(read_cursor);
   REQUIRE(read.first == nullptr);
 }
 
 TEST_CASE( "Reserve - shm") {
-  SlickQueue<int> queue(2);
+  SlickQueue<int> queue(2, "sq_reserve");
   auto reserved = queue.reserve();
   REQUIRE( reserved == 0 );
   REQUIRE( queue.reserve() == 1);
@@ -20,7 +20,7 @@ TEST_CASE( "Reserve - shm") {
 }
 
 TEST_CASE( "Read should fail w/o publish - shm") {
-  SlickQueue<int> queue(2);
+  SlickQueue<int> queue(2, "sq_read_fail");
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   auto read = queue.read(read_cursor);
@@ -29,7 +29,7 @@ TEST_CASE( "Read should fail w/o publish - shm") {
 }
 
 TEST_CASE( "Publish and read - shm" ) {
-  SlickQueue<int> queue(2);
+  SlickQueue<int> queue(2, "sq_publish_read");
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   *queue[reserved] = 5;
@@ -41,7 +41,7 @@ TEST_CASE( "Publish and read - shm" ) {
 }
 
 TEST_CASE( "Publish and read multiple - shm" ) {
-  SlickQueue<int> queue(4);
+  SlickQueue<int> queue(4, "sq_publish_read_multiple");
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   *queue[reserved] = 5;
@@ -73,7 +73,7 @@ TEST_CASE( "Publish and read multiple - shm" ) {
 }
 
 TEST_CASE("SHM test - shm") {
-    SlickQueue<int> queue(2, "sq_shared");
+    SlickQueue<int> queue(2, "sq_shm_test");
     uint64_t read_cursor = 0;
     auto reserved = queue.reserve();
     *queue[reserved] = 5;

--- a/tests/shm_tests.cpp
+++ b/tests/shm_tests.cpp
@@ -1,17 +1,18 @@
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
 #include "catch.hh"
 #include "../include/slick_queue.h"
 
 using namespace slick;
 
 TEST_CASE("Read empty queue - shm") {
-  SlickQueue<int, 2> queue;
+  SlickQueue<int> queue(2);
   uint64_t read_cursor = 0;
   auto read = queue.read(read_cursor);
   REQUIRE(read.first == nullptr);
 }
 
 TEST_CASE( "Reserve - shm") {
-  SlickQueue<int, 2> queue;
+  SlickQueue<int> queue(2);
   auto reserved = queue.reserve();
   REQUIRE( reserved == 0 );
   REQUIRE( queue.reserve() == 1);
@@ -19,7 +20,7 @@ TEST_CASE( "Reserve - shm") {
 }
 
 TEST_CASE( "Read should fail w/o publish - shm") {
-  SlickQueue<int, 2> queue;
+  SlickQueue<int> queue(2);
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   auto read = queue.read(read_cursor);
@@ -28,7 +29,7 @@ TEST_CASE( "Read should fail w/o publish - shm") {
 }
 
 TEST_CASE( "Publish and read - shm" ) {
-  SlickQueue<int, 2> queue;
+  SlickQueue<int> queue(2);
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   *queue[reserved] = 5;
@@ -40,7 +41,7 @@ TEST_CASE( "Publish and read - shm" ) {
 }
 
 TEST_CASE( "Publish and read multiple - shm" ) {
-  SlickQueue<int, 4> queue;
+  SlickQueue<int> queue(4);
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   *queue[reserved] = 5;
@@ -72,7 +73,7 @@ TEST_CASE( "Publish and read multiple - shm" ) {
 }
 
 TEST_CASE("SHM test - shm") {
-    SlickQueue<int, 2> queue("test");
+    SlickQueue<int> queue(2, "test");
     uint64_t read_cursor = 0;
     auto reserved = queue.reserve();
     *queue[reserved] = 5;

--- a/tests/shm_tests.cpp
+++ b/tests/shm_tests.cpp
@@ -1,17 +1,18 @@
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
 #include "catch.hh"
 #include "../include/slick_queue.h"
 
 using namespace slick;
 
 TEST_CASE("Read empty queue - shm") {
-  SlickQueue<int, 2> queue;
+  SlickQueue<int> queue(2);
   uint64_t read_cursor = 0;
   auto read = queue.read(read_cursor);
   REQUIRE(read.first == nullptr);
 }
 
 TEST_CASE( "Reserve - shm") {
-  SlickQueue<int, 2> queue;
+  SlickQueue<int> queue(2);
   auto reserved = queue.reserve();
   REQUIRE( reserved == 0 );
   REQUIRE( queue.reserve() == 1);
@@ -19,7 +20,7 @@ TEST_CASE( "Reserve - shm") {
 }
 
 TEST_CASE( "Read should fail w/o publish - shm") {
-  SlickQueue<int, 2> queue;
+  SlickQueue<int> queue(2);
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   auto read = queue.read(read_cursor);
@@ -28,7 +29,7 @@ TEST_CASE( "Read should fail w/o publish - shm") {
 }
 
 TEST_CASE( "Publish and read - shm" ) {
-  SlickQueue<int, 2> queue;
+  SlickQueue<int> queue(2);
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   *queue[reserved] = 5;
@@ -40,7 +41,7 @@ TEST_CASE( "Publish and read - shm" ) {
 }
 
 TEST_CASE( "Publish and read multiple - shm" ) {
-  SlickQueue<int, 4> queue;
+  SlickQueue<int> queue(4);
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   *queue[reserved] = 5;
@@ -72,7 +73,7 @@ TEST_CASE( "Publish and read multiple - shm" ) {
 }
 
 TEST_CASE("SHM test - shm") {
-    SlickQueue<int, 2> queue("test");
+    SlickQueue<int> queue(2, "sq_shared");
     uint64_t read_cursor = 0;
     auto reserved = queue.reserve();
     *queue[reserved] = 5;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1,11 +1,12 @@
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
 #include "catch.hh"
 #include "../include/slick_queue.h"
 
 using namespace slick;
 
 TEST_CASE("Read empty queue") {
-  SlickQueue<int, 2> queue("test");
+  SlickQueue<int> queue(2, "test");
   uint64_t read_cursor = 0;
   auto read = queue.read(read_cursor);
   REQUIRE(read.first == nullptr);
@@ -20,7 +21,7 @@ TEST_CASE("Read empty queue") {
 //}
 
 TEST_CASE( "Reserve") {
-  SlickQueue<int, 2> queue("test");
+  SlickQueue<int> queue(2, "test");
   auto reserved = queue.reserve();
   REQUIRE( reserved == 0 );
   REQUIRE( queue.reserve() == 1);
@@ -28,7 +29,7 @@ TEST_CASE( "Reserve") {
 }
 
 TEST_CASE( "Read should fail w/o publish") {
-  SlickQueue<int, 2> queue("test");
+  SlickQueue<int> queue(2, "test");
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   auto read = queue.read(read_cursor);
@@ -37,7 +38,7 @@ TEST_CASE( "Read should fail w/o publish") {
 }
 
 TEST_CASE( "Publish and read" ) {
-  SlickQueue<int, 2> queue("test");
+  SlickQueue<int> queue(2, "test");
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   *queue[reserved] = 5;
@@ -49,7 +50,7 @@ TEST_CASE( "Publish and read" ) {
 }
 
 TEST_CASE( "Publish and read multiple" ) {
-  SlickQueue<int, 4> queue("test");
+  SlickQueue<int> queue(4, "test");
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   *queue[reserved] = 5;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1,11 +1,12 @@
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
 #include "catch.hh"
 #include "../include/slick_queue.h"
 
 using namespace slick;
 
 TEST_CASE("Read empty queue") {
-  SlickQueue<int, 2> queue("test");
+  SlickQueue<int> queue(2, "sq_test1");
   uint64_t read_cursor = 0;
   auto read = queue.read(read_cursor);
   REQUIRE(read.first == nullptr);
@@ -20,7 +21,7 @@ TEST_CASE("Read empty queue") {
 //}
 
 TEST_CASE( "Reserve") {
-  SlickQueue<int, 2> queue("test");
+  SlickQueue<int> queue(2, "sq_test2");
   auto reserved = queue.reserve();
   REQUIRE( reserved == 0 );
   REQUIRE( queue.reserve() == 1);
@@ -28,7 +29,7 @@ TEST_CASE( "Reserve") {
 }
 
 TEST_CASE( "Read should fail w/o publish") {
-  SlickQueue<int, 2> queue("test");
+  SlickQueue<int> queue(2, "sq_test3");
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   auto read = queue.read(read_cursor);
@@ -37,7 +38,7 @@ TEST_CASE( "Read should fail w/o publish") {
 }
 
 TEST_CASE( "Publish and read" ) {
-  SlickQueue<int, 2> queue("test");
+  SlickQueue<int> queue(2, "sq_test4");
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   *queue[reserved] = 5;
@@ -49,7 +50,7 @@ TEST_CASE( "Publish and read" ) {
 }
 
 TEST_CASE( "Publish and read multiple" ) {
-  SlickQueue<int, 4> queue("test");
+  SlickQueue<int> queue(4, "sq_test5");
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   *queue[reserved] = 5;


### PR DESCRIPTION
## Summary
- implement POSIX shared memory backend for SlickQueue
- add proper cleanup for mapped regions on Unix
- adjust tests for new interface and disable POSIX signal handling in Catch

## Testing
- `cmake -S . -B build`
- `cmake --build build --target slick_queue_tests`
- `./build/tests/slick_queue_tests`


------
https://chatgpt.com/codex/tasks/task_e_688fd54fe3b48333a3d25a9d4437296b