### PR TITLE
Add Linux shared memory support #2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,4 +9,8 @@ set(CMAKE_CXX_STANDARD 17)
 add_library(slick_queue INTERFACE)
 target_include_directories(slick_queue INTERFACE include)
 
+if(UNIX AND NOT APPLE)
+    target_link_libraries(slick_queue INTERFACE rt)
+endif()
+
 add_subdirectory(tests EXCLUDE_FROM_ALL)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,3 +3,5 @@ project(slick_queue_tests LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 
 add_executable(slick_queue_tests tests.cpp shm_tests.cpp)
+
+target_link_libraries(slick_queue_tests PRIVATE slick_queue)

--- a/tests/shm_tests.cpp
+++ b/tests/shm_tests.cpp
@@ -1,17 +1,18 @@
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
 #include "catch.hh"
 #include "../include/slick_queue.h"
 
 using namespace slick;
 
 TEST_CASE("Read empty queue - shm") {
-  SlickQueue<int, 2> queue;
+  SlickQueue<int> queue(2);
   uint64_t read_cursor = 0;
   auto read = queue.read(read_cursor);
   REQUIRE(read.first == nullptr);
 }
 
 TEST_CASE( "Reserve - shm") {
-  SlickQueue<int, 2> queue;
+  SlickQueue<int> queue(2);
   auto reserved = queue.reserve();
   REQUIRE( reserved == 0 );
   REQUIRE( queue.reserve() == 1);
@@ -19,7 +20,7 @@ TEST_CASE( "Reserve - shm") {
 }
 
 TEST_CASE( "Read should fail w/o publish - shm") {
-  SlickQueue<int, 2> queue;
+  SlickQueue<int> queue(2);
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   auto read = queue.read(read_cursor);
@@ -28,7 +29,7 @@ TEST_CASE( "Read should fail w/o publish - shm") {
 }
 
 TEST_CASE( "Publish and read - shm" ) {
-  SlickQueue<int, 2> queue;
+  SlickQueue<int> queue(2);
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   *queue[reserved] = 5;
@@ -40,7 +41,7 @@ TEST_CASE( "Publish and read - shm" ) {
 }
 
 TEST_CASE( "Publish and read multiple - shm" ) {
-  SlickQueue<int, 4> queue;
+  SlickQueue<int> queue(4);
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   *queue[reserved] = 5;
@@ -72,7 +73,7 @@ TEST_CASE( "Publish and read multiple - shm" ) {
 }
 
 TEST_CASE("SHM test - shm") {
-    SlickQueue<int, 2> queue("test");
+    SlickQueue<int> queue(2, "test");
     uint64_t read_cursor = 0;
     auto reserved = queue.reserve();
     *queue[reserved] = 5;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1,11 +1,12 @@
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
 #include "catch.hh"
 #include "../include/slick_queue.h"
 
 using namespace slick;
 
 TEST_CASE("Read empty queue") {
-  SlickQueue<int, 2> queue("test");
+  SlickQueue<int> queue(2, "test");
   uint64_t read_cursor = 0;
   auto read = queue.read(read_cursor);
   REQUIRE(read.first == nullptr);
@@ -20,7 +21,7 @@ TEST_CASE("Read empty queue") {
 //}
 
 TEST_CASE( "Reserve") {
-  SlickQueue<int, 2> queue("test");
+  SlickQueue<int> queue(2, "test");
   auto reserved = queue.reserve();
   REQUIRE( reserved == 0 );
   REQUIRE( queue.reserve() == 1);
@@ -28,7 +29,7 @@ TEST_CASE( "Reserve") {
 }
 
 TEST_CASE( "Read should fail w/o publish") {
-  SlickQueue<int, 2> queue("test");
+  SlickQueue<int> queue(2, "test");
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   auto read = queue.read(read_cursor);
@@ -37,7 +38,7 @@ TEST_CASE( "Read should fail w/o publish") {
 }
 
 TEST_CASE( "Publish and read" ) {
-  SlickQueue<int, 2> queue("test");
+  SlickQueue<int> queue(2, "test");
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   *queue[reserved] = 5;
@@ -49,7 +50,7 @@ TEST_CASE( "Publish and read" ) {
 }
 
 TEST_CASE( "Publish and read multiple" ) {
-  SlickQueue<int, 4> queue("test");
+  SlickQueue<int> queue(4, "test");
   uint64_t read_cursor = 0;
   auto reserved = queue.reserve();
   *queue[reserved] = 5;


### PR DESCRIPTION
## Summary
- Link slick_queue against rt on Unix systems and let tests pull in the interface library
- Implement POSIX shared-memory backend using shm_open, ftruncate and mmap with proper cleanup
- Adjust tests for new SlickQueue constructor and disable Catch POSIX signal handling

## Testing
- `cmake -S . -B build`
- `cmake --build build --target slick_queue_tests`
- `./build/tests/slick_queue_tests`


------
https://chatgpt.com/codex/tasks/task_e_688fec4c945883339eb46e90a0cf9e55